### PR TITLE
Return SolidList and SolidSet for map methods

### DIFF
--- a/collections/src/main/java/solid/collections/SolidList.java
+++ b/collections/src/main/java/solid/collections/SolidList.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+import solid.functions.Func1;
 import solid.stream.Stream;
 
 import static java.util.Arrays.asList;
@@ -260,5 +261,14 @@ public class SolidList<T> extends Stream<T> implements List<T>, Parcelable {
         return "SolidList{" +
             "list=" + list +
             '}';
+    }
+
+    @Override
+    public <R> SolidList<R> map(Func1<T, R> func) {
+        final List<R> result = new ArrayList<>(list.size());
+        for (T item : list) {
+            result.add(func.call(item));
+        }
+        return new SolidList<>(result);
     }
 }

--- a/collections/src/main/java/solid/collections/SolidSet.java
+++ b/collections/src/main/java/solid/collections/SolidSet.java
@@ -9,8 +9,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
+import solid.functions.Func1;
 import solid.stream.Stream;
 
 /**
@@ -176,5 +178,14 @@ public class SolidSet<T> extends Stream<T> implements Set<T>, Parcelable {
         return "SolidSet{" +
             "set=" + set +
             '}';
+    }
+
+    @Override
+    public <R> SolidSet<R> map(Func1<T, R> func) {
+        final List<R> result = new ArrayList<>(set.size());
+        for (T item : set) {
+            result.add(func.call(item));
+        }
+        return new SolidSet<>(result);
     }
 }


### PR DESCRIPTION
I feel like it would be more convenient, for instance, chains of calls like `someSolidList.map(Integer::toString).get(3)` will be possible. Right now you have to call `collect(toSolidList())` which is kinda annoying.

If you like it I could do the same to filter