### PR TITLE
Fix for map iteration issues in unit tests for collections

### DIFF
--- a/collections/src/androidTest/java/solid/collections/SolidMapTest.java
+++ b/collections/src/androidTest/java/solid/collections/SolidMapTest.java
@@ -180,7 +180,7 @@ public class SolidMapTest {
     }
 
     private <T> void assertSetEquals(Set<T> expected, Set<T> actual) {
-        assertArrayEquals(expected.toArray(), actual.toArray());
+        assertEquals(expected, actual);
     }
 
     private LinkedHashMap<Integer, Integer> create123map234() {

--- a/collections/src/androidTest/java/solid/collectors/ToSolidMapTest.java
+++ b/collections/src/androidTest/java/solid/collectors/ToSolidMapTest.java
@@ -5,19 +5,20 @@ import android.support.test.runner.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import solid.collections.Pair;
 import solid.collections.SolidMap;
 import solid.functions.Func1;
 import solid.stream.Range;
 
+import static java.lang.String.valueOf;
 import static testkit.AssertIterableEquals.assertIterableEquals;
 
 @RunWith(AndroidJUnit4.class)
 public class ToSolidMapTest {
 
-    public static final SolidMap<String, Integer> MAP = new SolidMap<>(new HashMap<String, Integer>() {{
+    public static final SolidMap<String, Integer> MAP = new SolidMap<>(new LinkedHashMap<String, Integer>() {{
         put("1", 1);
         put("2", 2);
         put("3", 3);
@@ -27,7 +28,7 @@ public class ToSolidMapTest {
     public void testToSolidMap2() throws Exception {
         assertIterableEquals(MAP, Range.range(1, 4).collect(ToSolidMap.toSolidMap(new Func1<Integer, String>() {
             @Override
-            public String call(Integer it) {return "" + it;}
+            public String call(Integer it) {return valueOf(it);}
         }, new Func1<Integer, Integer>() {
             @Override
             public Integer call(Integer value) {
@@ -40,7 +41,7 @@ public class ToSolidMapTest {
     public void testToSolidMap1() throws Exception {
         assertIterableEquals(MAP, Range.range(1, 4).collect(ToSolidMap.toSolidMap(new Func1<Integer, String>() {
             @Override
-            public String call(Integer it) {return "" + it;}
+            public String call(Integer it) {return valueOf(it);}
         })));
     }
 
@@ -49,7 +50,7 @@ public class ToSolidMapTest {
         SolidMap<String, Integer> converted = Range.range(1, 4)
             .map(new Func1<Integer, Pair<String, Integer>>() {
                 @Override
-                public Pair<String, Integer> call(Integer it) {return new Pair<>("" + it, it.intValue());}
+                public Pair<String, Integer> call(Integer it) {return new Pair<>(valueOf(it), it);}
             })
             .collect(ToSolidMap.<String, Integer>pairsToSolidMap());
         assertIterableEquals(MAP, converted);
@@ -60,7 +61,7 @@ public class ToSolidMapTest {
         SolidMap<String, Integer> converted = Range.range(1, 4)
             .map(new Func1<Integer, Pair<String, Integer>>() {
                 @Override
-                public Pair<String, Integer> call(Integer it) {return new Pair<>("" + it, it.intValue());}
+                public Pair<String, Integer> call(Integer it) {return new Pair<>(valueOf(it), it);}
             })
             .collect(ToSolidMap.<String, Integer>pairsToSolidMap());
 


### PR DESCRIPTION
I ran tests against API 19 and some of them failed. The reason is `toArray` does not necessarily preserve the order of items (even for `LinkedHashMap`), and in `ToSolidMapTest`, `HashMap` was used where `LinkedHashMap` should have been used.
Also, couple of minor style fixes in `ToSolidListTest`.