### PR TITLE
add Optional.stream()

### DIFF
--- a/streams/src/main/java/solid/optional/Optional.java
+++ b/streams/src/main/java/solid/optional/Optional.java
@@ -92,15 +92,7 @@ public class Optional<T> {
      * @return the optional value as a {@code Stream}
      */
     public Stream<T> stream() {
-        if (!isPresent()) {
-            return Stream.of();
-        } else {
-            if (value instanceof Iterable) {
-                return Stream.stream((Iterable<T>) value);
-            } else {
-                return Stream.of(value);
-            }
-        }
+        return value == null ? Stream.<T>of() : Stream.of(value);
     }
 
     @Override

--- a/streams/src/main/java/solid/optional/Optional.java
+++ b/streams/src/main/java/solid/optional/Optional.java
@@ -3,6 +3,7 @@ package solid.optional;
 import solid.functions.Action1;
 import solid.functions.Func0;
 import solid.functions.Func1;
+import solid.stream.Stream;
 
 /**
  * Optional is a wrapper around a value that can be empty (null).
@@ -82,6 +83,24 @@ public class Optional<T> {
      */
     public <R> Optional<R> map(Func1<T, R> func1) {
         return value == null ? Optional.<R>empty() : Optional.of(func1.call(value));
+    }
+
+    /**
+     * If a value is present return a sequential {@link Stream} containing only
+     * that value, otherwise return an empty {@code Stream}.
+     *
+     * @return the optional value as a {@code Stream}
+     */
+    public Stream<T> stream() {
+        if (!isPresent()) {
+            return Stream.of();
+        } else {
+            if (value instanceof Iterable) {
+                return Stream.stream((Iterable<T>) value);
+            } else {
+                return Stream.of(value);
+            }
+        }
     }
 
     @Override

--- a/streams/src/test/java/solid/optional/OptionalTest.java
+++ b/streams/src/test/java/solid/optional/OptionalTest.java
@@ -2,12 +2,17 @@ package solid.optional;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import solid.functions.Action1;
 import solid.functions.Func0;
 import solid.functions.Func1;
+import solid.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -15,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static test_utils.AssertIterableEquals.assertIterableEquals;
 
 public class OptionalTest {
 
@@ -31,7 +37,9 @@ public class OptionalTest {
         assertEquals(1, o.or(1));
         assertEquals(1, o.or(new Func0<Object>() {
             @Override
-            public Object call() {return 1;}
+            public Object call() {
+                return 1;
+            }
         }));
         assertNull(o.orNull());
         assertNull(o.map(null).orNull());
@@ -76,5 +84,27 @@ public class OptionalTest {
         assertEquals(o.hashCode(), Optional.of(1).hashCode());
 
         assertEquals((Integer) 1, o.get());
+    }
+
+    @Test
+    public void testStream() throws Exception {
+        Optional<List<Integer>> o = Optional.of(Arrays.asList(1, 2, 3, 4));
+        assertNotNull(o.stream());
+        assertTrue(o.stream().first().isPresent());
+
+        Stream<Integer> s = o.stream().flatMap(new Func1<List<Integer>, Iterable<Integer>>() {
+            @Override
+            public Iterable<Integer> call(List<Integer> value) {
+                return value;
+            }
+        });
+        assertEquals(Integer.valueOf(1), s.first().get());
+        assertEquals(Integer.valueOf(4), s.last().get());
+
+        assertEquals(Optional.empty().stream(), Stream.of());
+
+        assertIterableEquals(s, Arrays.asList(1, 2, 3, 4));
+
+        assertEquals(Optional.of("Test").stream().first().get(), "Test");
     }
 }


### PR DESCRIPTION
Let's you convert an Optional to a Stream. Useful if you have a ```@Nullable``` list.

Instead of this
```
    private static <T> Stream<T> stream(@Nullable T object) {
        return Optional.of(object).map(value -> {
            if (value instanceof Iterable) {
                return Stream.stream((Iterable<T>) value);
            } else {
                return Stream.of(value);
            }
        }).or(Stream.of());
    }
```
you get this
```
    private static <T> Stream<T> stream(@Nullable T object) {
        return Optional.of(object).stream();
    }
```
